### PR TITLE
Add initializeValidatorSet function to ACP99Manager

### DIFF
--- a/contracts/src/contracts/ACP99/ACP99Manager.sol
+++ b/contracts/src/contracts/ACP99/ACP99Manager.sol
@@ -13,11 +13,15 @@ import {
     WarpMessage
 } from "@avalabs/subnet-evm-contracts@1.2.0/contracts/interfaces/IWarpMessenger.sol";
 import {Ownable2Step} from "@openzeppelin/contracts@4.9.6/access/Ownable2Step.sol";
-
-import {SafeMath} from "@openzeppelin/contracts@4.9.6/utils/math/SafeMath.sol";
 import {EnumerableMap} from "@openzeppelin/contracts@4.9.6/utils/structs/EnumerableMap.sol";
 
-/// @custom:security-contact security@suzaku.network
+/**
+ * @title ACP99Manager
+ * @author ADDPHO
+ * @notice The ACP99Manager contract is responsible for managing the validator set of a Subnet.
+ * It is meant to be used as the Subnet manager address in the `ConvertSubnetTx`.
+ * @custom:security-contact security@suzaku.network
+ */
 contract ACP99Manager is Ownable2Step, IACP99Manager {
     using EnumerableMap for EnumerableMap.Bytes32ToBytes32Map;
 
@@ -410,7 +414,7 @@ contract ACP99Manager is Ownable2Step, IACP99Manager {
             uint64 periodDuration = validation.periods[i].endTime - validation.periods[i].startTime;
             averageWeight += validation.periods[i].weight * periodDuration;
         }
-        averageWeight = SafeMath.div(averageWeight, validation.activeSeconds);
+        averageWeight = averageWeight / validation.activeSeconds;
 
         IACP99SecurityModule.ValidatorUptimeInfo memory uptimeInfo = IACP99SecurityModule
             .ValidatorUptimeInfo({

--- a/contracts/src/contracts/ACP99/ACP99Manager.sol
+++ b/contracts/src/contracts/ACP99/ACP99Manager.sol
@@ -50,23 +50,14 @@ contract ACP99Manager is Ownable2Step, IACP99Manager {
     /// @notice The total weight of the current Subnet validator set
     uint64 public subnetTotalWeight;
 
-    /**
-     * @notice The list of validationIDs associated with a validator of the Subnet
-     * @notice NodeID => validationID[]
-     */
-    mapping(bytes32 => bytes32[]) private subnetValidatorValidations;
+    /// @notice The list of validationIDs associated with a validator of the Subnet
+    mapping(bytes32 nodeID => bytes32[] validationIDs) private subnetValidatorValidations;
 
-    /**
-     * @notice The validation corresponding to each validationID
-     * @notice validationID => SubnetValidation
-     */
-    mapping(bytes32 => Validation) private subnetValidations;
+    /// @notice The validation corresponding to each validationID
+    mapping(bytes32 validationID => Validation validation) private subnetValidations;
 
-    /**
-     * @notice The registration message corresponding to a validationID such that it can be re-sent
-     * @notice validationID => messageBytes
-     */
-    mapping(bytes32 => bytes) public pendingRegisterValidationMessages;
+    /// @notice The registration message corresponding to a validationID such that it can be re-sent
+    mapping(bytes32 validationID => bytes messageBytes) public pendingRegisterValidationMessages;
 
     modifier onlySecurityModule() {
         if (msg.sender != address(securityModule)) {
@@ -410,7 +401,7 @@ contract ACP99Manager is Ownable2Step, IACP99Manager {
 
         // Compute the average weight of the validator during all periods
         uint256 averageWeight;
-        for (uint256 i = 0; i < nonce; i++) {
+        for (uint256 i; i < nonce; ++i) {
             uint64 periodDuration = validation.periods[i].endTime - validation.periods[i].startTime;
             averageWeight += validation.periods[i].weight * periodDuration;
         }

--- a/contracts/src/contracts/ACP99/SecurityModules/ACP99PoAModule.sol
+++ b/contracts/src/contracts/ACP99/SecurityModules/ACP99PoAModule.sol
@@ -7,8 +7,16 @@ import {IACP99Manager} from "../../../interfaces/ACP99/IACP99Manager.sol";
 import {IACP99SecurityModule} from "../../../interfaces/ACP99/IACP99SecurityModule.sol";
 import {Ownable2Step} from "@openzeppelin/contracts@4.9.6/access/Ownable2Step.sol";
 
+/**
+ * @title ACP99PoAModule
+ * @author ADDPHO
+ * @notice The ACP99PoAModule is a security module for the ACP99Manager contract.
+ * It implements the Proof of Authority (PoA) mechanism for managing the validator set of a Subnet.
+ * @custom:security-contact security@suzaku.network
+ */
 contract ACP99PoAModule is Ownable2Step, IACP99SecurityModule {
-    IACP99Manager public manager;
+    /// @notice The ACP99Manager contract that relies on this security module
+    IACP99Manager public immutable manager;
 
     constructor(address _manager) Ownable2Step() {
         if (_manager == address(0)) {

--- a/contracts/src/contracts/ACP99/SecurityModules/ACP99PoAModule.sol
+++ b/contracts/src/contracts/ACP99/SecurityModules/ACP99PoAModule.sol
@@ -76,7 +76,7 @@ contract ACP99PoAModule is Ownable2Step, IACP99SecurityModule {
     }
 
     /// @inheritdoc IACP99SecurityModule
-    function handleValidatorRegistration(ValidatiorRegistrationInfo memory validatorInfo)
+    function handleValidatorRegistration(ValidatiorRegistrationInfo memory /*validatorInfo*/ )
         external
         onlyManager
     {
@@ -84,7 +84,7 @@ contract ACP99PoAModule is Ownable2Step, IACP99SecurityModule {
     }
 
     /// @inheritdoc IACP99SecurityModule
-    function handleValidatorWeightChange(ValidatorWeightChangeInfo memory weightChangeInfo)
+    function handleValidatorWeightChange(ValidatorWeightChangeInfo memory /*weightChangeInfo*/ )
         external
         onlyManager
     {

--- a/contracts/src/contracts/ACP99/ValidatorMessages.sol
+++ b/contracts/src/contracts/ACP99/ValidatorMessages.sol
@@ -1,13 +1,31 @@
 // SPDX-License-Identifier: Ecosystem
 // SPDX-FileCopyrightText: Copyright 2023 Ava Labs, Inc.
 
+// Copied from @avalabs/teleporter/validator-manager/ValidatorMessages.sol
+
 pragma solidity 0.8.18;
 
 library ValidatorMessages {
+    // Copied from @avalabs/teleporter/validator-manager/interfaces/IValidatorManager.sol
+    struct InitialValidator {
+        bytes32 nodeID;
+        uint64 weight;
+        bytes blsPublicKey;
+    }
+
+    // Copied from @avalabs/teleporter/validator-manager/interfaces/IValidatorManager.sol
+    struct SubnetConversionData {
+        bytes32 convertSubnetTxID;
+        bytes32 validatorManagerBlockchainID;
+        address validatorManagerAddress;
+        InitialValidator[] initialValidators;
+    }
+
     // The information that uniquely identifies a subnet validation period.
     // The validationID is the SHA-256 hash of the concatenation of the CODEC_ID,
-    // REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID, and the concatenated ValidationInfo fields.
-    struct ValidationInfo {
+    // REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID, and the concatenated ValidationPeriod fields.
+
+    struct ValidationPeriod {
         bytes32 subnetID;
         bytes32 nodeID;
         uint64 weight;
@@ -18,27 +36,176 @@ library ValidatorMessages {
     // The P-Chain uses a hardcoded codecID of 0 for all messages.
     uint16 internal constant CODEC_ID = 0;
 
+    // The P-Chain signs a SubnetConversion message that is used to verify the Subnet's initial validators.
+    uint32 internal constant SUBNET_CONVERSION_MESSAGE_TYPE_ID = 0;
+
     // Subnets send a RegisterSubnetValidator message to the P-Chain to register a validator.
-    uint32 internal constant REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID = 0;
+    uint32 internal constant REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID = 1;
 
     // Subnets can send a SetSubnetValidatorWeight message to the P-Chain to update a validator's weight.
     // The P-Chain responds with a SetSubnetValidatorWeight message acknowledging the weight update.
-    uint32 internal constant SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID = 1;
+    uint32 internal constant SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID = 2;
 
     // The P-Chain responds with a RegisterSubnetValidator message indicating whether the registration was successful
     // for the given validation ID.
-    uint32 internal constant SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID = 2;
+    uint32 internal constant SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID = 3;
 
-    // The P-Chain responds with a SetSubnetValidatorWeight message indicating whether the weight update was successful
+    // The P-Chain responds with a SubnetValidatorWeightUpdateMessage message indicating whether the weight update was successful
     // for the given validation ID.
-    uint32 internal constant SET_SUBNET_VALIDATOR_WEIGHT_UPDATE_MESSAGE_TYPE_ID = 3;
+    uint32 internal constant SUBNET_VALIDATOR_WEIGHT_UPDATE_MESSAGE_TYPE_ID = 4;
 
     // The Subnet will self-sign a ValidationUptimeMessage to be provided when a validator is initiating
     // the end of their validation period.
-    uint32 internal constant VALIDATION_UPTIME_MESSAGE_TYPE_ID = 4;
+    uint32 internal constant VALIDATION_UPTIME_MESSAGE_TYPE_ID = 5;
 
-    // TODO: The implementation of these packing and unpacking functions is neither tested nor optimized at all.
-    // Full test coverage should be provided, and the implementation should be optimized for gas efficiency.
+    error InvalidMessageLength();
+    error InvalidCodecID();
+    error InvalidMessageType();
+    error InvalidSignatureLength();
+
+    /**
+     * @notice Packs a SubnetConversionMessage message into a byte array.
+     * The message format specification is:
+     * +--------------------+----------+----------+
+     * |            codecID :   uint16 |  2 bytes |
+     * +--------------------+----------+----------+
+     * |             typeID :   uint32 |  4 bytes |
+     * +--------------------+----------+----------+
+     * | subnetConversionID : [32]byte | 32 bytes |
+     * +--------------------+----------+----------+
+     *                                 | 38 bytes |
+     *                                 +----------+
+     *
+     * @param subnetConversionID The subnet conversion ID to pack into the message.
+     * @return The packed message.
+     */
+    function packSubnetConversionMessage(bytes32 subnetConversionID)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(CODEC_ID, SUBNET_CONVERSION_MESSAGE_TYPE_ID, subnetConversionID);
+    }
+
+    /**
+     * @notice Unpacks a byte array as a SubnetConversionMessage message.
+     * The message format specification is the same as the one used in above for packing.
+     *
+     * @param input The byte array to unpack.
+     * @return the unpacked subnetConversionID.
+     */
+    function unpackSubnetConversionMessage(bytes memory input) internal pure returns (bytes32) {
+        if (input.length != 38) {
+            revert InvalidMessageLength();
+        }
+
+        // Unpack the codec ID
+        uint16 codecID;
+        for (uint256 i; i < 2; ++i) {
+            codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
+        }
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
+
+        // Unpack the type ID
+        uint32 typeID;
+        for (uint256 i; i < 4; ++i) {
+            typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
+        }
+        if (typeID != SUBNET_CONVERSION_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
+
+        // Unpack the subnetConversionID
+        bytes32 subnetConversionID;
+        for (uint256 i; i < 32; ++i) {
+            subnetConversionID |= bytes32(uint256(uint8(input[i + 6])) << (8 * (31 - i)));
+        }
+
+        return subnetConversionID;
+    }
+
+    /**
+     * @notice Packs SubnetConversionData into a byte array.
+     * This byte array is the SHA256 pre-image of the subnetConversionID hash
+     * The message format specification is:
+     *
+     * +-------------------+---------------+---------------------------------------------------------+
+     * | convertSubnetTxID : [32]byte        |                                              32 bytes |
+     * +-------------------+-----------------+-------------------------------------------------------+
+     * |    managerChainID : [32]byte        |                                              32 bytes |
+     * +-------------------+-----------------+-------------------------------------------------------+
+     * |    managerAddress : []byte          |                         4 + len(managerAddress) bytes |
+     * +-------------------+-----------------+-------------------------------------------------------+
+     * |        validators : []ValidatorData |                        4 + len(validators) * 88 bytes |
+     * +-------------------+-----------------+-------------------------------------------------------+
+     *                                       | 72 + len(managerAddress) + len(validators) * 88 bytes |
+     *                                       +-------------------------------------------------------+
+     * And ValidatorData:
+     * +--------------+----------+-----------+
+     * |       nodeID : [32]byte |  32 bytes |
+     * +--------------+----------+-----------+
+     * |       weight :   uint64 |   8 bytes |
+     * +--------------+----------+-----------+
+     * | blsPublicKey : [48]byte |  48 bytes |
+     * +--------------+----------+-----------+
+     *                           |  88 bytes |
+     *                           +-----------+
+     *
+     * @param subnetConversionData The struct representing data to pack into the message.
+     * @return The packed message.
+     */
+    function packSubnetConversionData(SubnetConversionData calldata subnetConversionData)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        // The formula for the length in the comment above is VM agnostic, but in EVM
+        // the address length is always 20 bytes so the constant term is 72 + 20 = 92.
+        bytes memory res = new bytes(92 + subnetConversionData.initialValidators.length * 88);
+        // Pack the convertSubnetTx ID
+        for (uint256 i; i < 32; ++i) {
+            res[i] = subnetConversionData.convertSubnetTxID[i];
+        }
+        // Pack the validatorManagerBlockchainID
+        for (uint256 i; i < 32; ++i) {
+            res[i + 32] = subnetConversionData.validatorManagerBlockchainID[i];
+        }
+        // Pack the ADDRESS_LENGTH
+        for (uint256 i; i < 4; ++i) {
+            res[i + 64] = bytes1(uint8(20 >> (8 * (3 - i))));
+        }
+        // Pack the address
+        bytes20 addrBytes = bytes20(subnetConversionData.validatorManagerAddress);
+        for (uint256 i = 0; i < 20; ++i) {
+            res[i + 68] = addrBytes[i];
+        }
+
+        // Pack the initial validators length
+        uint32 ivLength = uint32(subnetConversionData.initialValidators.length);
+        for (uint256 i; i < 4; ++i) {
+            res[i + 88] = bytes1(uint8(ivLength >> (8 * (3 - i))));
+        }
+
+        for (uint256 i = 0; i < subnetConversionData.initialValidators.length; i++) {
+            uint256 offset = 92 + i * 88;
+            // Pack the nodeID
+            for (uint256 j; j < 32; ++j) {
+                res[offset + j] = subnetConversionData.initialValidators[i].nodeID[j];
+            }
+            // Pack the weight
+            for (uint256 j; j < 8; ++j) {
+                res[offset + 32 + j] =
+                    bytes1(uint8(subnetConversionData.initialValidators[i].weight >> (8 * (7 - j))));
+            }
+            // Pack the blsPublicKey
+            for (uint256 j; j < 48; ++j) {
+                res[offset + 40 + j] = subnetConversionData.initialValidators[i].blsPublicKey[j];
+            }
+        }
+        return res;
+    }
 
     /**
      * @notice Packs a RegisterSubnetValidatorMessage message into a byte array.
@@ -61,48 +228,28 @@ library ValidatorMessages {
      *                           | 134 bytes |
      *                           +-----------+
      *
-     * @param validationInfo The information to pack into the message.
+     * @param validationPeriod The information to pack into the message.
      * @return The validationID and the packed message.
      */
-    function packRegisterSubnetValidatorMessage(ValidationInfo memory validationInfo)
+    function packRegisterSubnetValidatorMessage(ValidationPeriod memory validationPeriod)
         internal
         pure
         returns (bytes32, bytes memory)
     {
-        require(
-            validationInfo.blsPublicKey.length == 48, "StakingMessages: Invalid signature length"
-        );
-        bytes memory res = new bytes(134);
-        // Pack the codec ID
-        for (uint256 i; i < 2; ++i) {
-            res[i] = bytes1(uint8(CODEC_ID >> uint8((8 * (1 - i)))));
-        }
-        // Pack the type ID
-        for (uint256 i; i < 4; ++i) {
-            res[i + 2] =
-                bytes1(uint8(REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID >> uint8((8 * (3 - i)))));
+        if (validationPeriod.blsPublicKey.length != 48) {
+            revert InvalidMessageLength();
         }
 
-        // Pack the subnetID
-        for (uint256 i; i < 32; ++i) {
-            res[i + 6] = validationInfo.subnetID[i];
-        }
-        // Pack the nodeID
-        for (uint256 i; i < 32; ++i) {
-            res[i + 38] = validationInfo.nodeID[i];
-        }
-        // Pack the weight
-        for (uint256 i; i < 8; ++i) {
-            res[i + 70] = bytes1(uint8(validationInfo.weight >> uint8((8 * (7 - i)))));
-        }
-        // Pack the blsPublicKey
-        for (uint256 i; i < 48; ++i) {
-            res[i + 78] = validationInfo.blsPublicKey[i];
-        }
-        // Pack the registration expiry
-        for (uint256 i; i < 8; ++i) {
-            res[i + 126] = bytes1(uint8(validationInfo.registrationExpiry >> uint64((8 * (7 - i)))));
-        }
+        // solhint-disable-next-line func-named-parameters
+        bytes memory res = abi.encodePacked(
+            CODEC_ID,
+            REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID,
+            validationPeriod.subnetID,
+            validationPeriod.nodeID,
+            validationPeriod.weight,
+            validationPeriod.blsPublicKey,
+            validationPeriod.registrationExpiry
+        );
         return (sha256(res), res);
     }
 
@@ -111,31 +258,34 @@ library ValidatorMessages {
      * The message format specification is the same as the one used in above for packing.
      *
      * @param input The byte array to unpack.
-     * @return the unpacked ValidationInfo.
+     * @return the unpacked ValidationPeriod.
      */
     function unpackRegisterSubnetValidatorMessage(bytes memory input)
         internal
         pure
-        returns (ValidationInfo memory)
+        returns (ValidationPeriod memory)
     {
-        require(input.length == 134, "ValidatorMessages: Invalid message length");
+        if (input.length != 134) {
+            revert InvalidMessageLength();
+        }
 
         // Unpack the codec ID
         uint16 codecID;
         for (uint256 i; i < 2; ++i) {
             codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
         }
-        require(codecID == CODEC_ID, "ValidatorMessages: Invalid codec ID");
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
 
         // Unpack the type ID
         uint32 typeID;
         for (uint256 i; i < 4; ++i) {
             typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
         }
-        require(
-            typeID == REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID,
-            "ValidatorMessages: Invalid message type"
-        );
+        if (typeID != REGISTER_SUBNET_VALIDATOR_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
 
         // Unpack the subnetID
         bytes32 subnetID;
@@ -167,7 +317,7 @@ library ValidatorMessages {
             expiry |= uint64(uint8(input[i + 126])) << uint64((8 * (7 - i)));
         }
 
-        return ValidationInfo({
+        return ValidationPeriod({
             subnetID: subnetID,
             nodeID: nodeID,
             weight: weight,
@@ -200,23 +350,9 @@ library ValidatorMessages {
         bytes32 validationID,
         bool valid
     ) internal pure returns (bytes memory) {
-        bytes memory res = new bytes(39);
-        // Pack the codec ID.
-        for (uint256 i; i < 2; ++i) {
-            res[i] = bytes1(uint8(CODEC_ID >> (8 * (1 - i))));
-        }
-        // Pack the type ID.
-        for (uint256 i; i < 4; ++i) {
-            res[i + 2] =
-                bytes1(uint8(SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID >> (8 * (3 - i))));
-        }
-        // Pack the validation ID.
-        for (uint256 i; i < 32; ++i) {
-            res[i + 6] = bytes1(uint8(uint256(validationID >> (8 * (31 - i)))));
-        }
-        // Pack the validity.
-        res[38] = bytes1(valid ? 1 : 0);
-        return res;
+        return abi.encodePacked(
+            CODEC_ID, SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID, validationID, valid
+        );
     }
 
     /**
@@ -232,23 +368,26 @@ library ValidatorMessages {
         pure
         returns (bytes32, bool)
     {
-        require(input.length == 39, "ValidatorMessages: Invalid message length");
+        if (input.length != 39) {
+            revert InvalidMessageLength();
+        }
         // Unpack the codec ID
         uint16 codecID;
         for (uint256 i; i < 2; ++i) {
             codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
         }
-        require(codecID == CODEC_ID, "ValidatorMessages: Invalid codec ID");
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
 
         // Unpack the type ID
         uint32 typeID;
         for (uint256 i; i < 4; ++i) {
             typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
         }
-        require(
-            typeID == SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID,
-            "ValidatorMessages: Invalid message type"
-        );
+        if (typeID != SUBNET_VALIDATOR_REGISTRATION_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
 
         // Unpack the validation ID.
         bytes32 validationID;
@@ -289,28 +428,9 @@ library ValidatorMessages {
         uint64 nonce,
         uint64 weight
     ) internal pure returns (bytes memory) {
-        bytes memory res = new bytes(54);
-        // Pack the codec ID.
-        for (uint256 i; i < 2; ++i) {
-            res[i] = bytes1(uint8(CODEC_ID >> (8 * (1 - i))));
-        }
-        // Pack the type ID.
-        for (uint256 i; i < 4; ++i) {
-            res[i + 2] = bytes1(uint8(SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID >> (8 * (3 - i))));
-        }
-        // Pack the validation ID.
-        for (uint256 i; i < 32; ++i) {
-            res[i + 6] = bytes1(uint8(uint256(validationID >> (8 * (31 - i)))));
-        }
-        // Pack the nonce.
-        for (uint256 i; i < 8; ++i) {
-            res[i + 38] = bytes1(uint8(nonce >> (8 * (7 - i))));
-        }
-        // Pack the weight.
-        for (uint256 i; i < 8; ++i) {
-            res[i + 46] = bytes1(uint8(weight >> (8 * (7 - i))));
-        }
-        return res;
+        return abi.encodePacked(
+            CODEC_ID, SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID, validationID, nonce, weight
+        );
     }
 
     /**
@@ -325,24 +445,110 @@ library ValidatorMessages {
         pure
         returns (bytes32, uint64, uint64)
     {
-        require(input.length == 54, "ValidatorMessages: Invalid message length");
+        if (input.length != 54) {
+            revert InvalidMessageLength();
+        }
 
         // Unpack the codec ID.
         uint16 codecID;
         for (uint256 i; i < 2; ++i) {
             codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
         }
-        require(codecID == CODEC_ID, "ValidatorMessages: Invalid codec ID");
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
 
         // Unpack the type ID.
         uint32 typeID;
         for (uint256 i; i < 4; ++i) {
             typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
         }
-        require(
-            typeID == SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID,
-            "ValidatorMessages: Invalid message type"
+        if (typeID != SET_SUBNET_VALIDATOR_WEIGHT_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
+
+        // Unpack the validation ID.
+        bytes32 validationID;
+        for (uint256 i; i < 32; ++i) {
+            validationID |= bytes32(uint256(uint8(input[i + 6])) << (8 * (31 - i)));
+        }
+
+        // Unpack the nonce.
+        uint64 nonce;
+        for (uint256 i; i < 8; ++i) {
+            nonce |= uint64(uint8(input[i + 38])) << uint64((8 * (7 - i)));
+        }
+
+        // Unpack the weight.
+        uint64 weight;
+        for (uint256 i; i < 8; ++i) {
+            weight |= uint64(uint8(input[i + 46])) << uint64((8 * (7 - i)));
+        }
+
+        return (validationID, nonce, weight);
+    }
+
+    /**
+     * @notice Packs a SubnetValidatorWeightUpdateMessage into a byte array.
+     * The message format specification is:
+     * +--------------+----------+----------+
+     * |      codecID :   uint16 |  2 bytes |
+     * +--------------+----------+----------+
+     * |       typeID :   uint32 |  4 bytes |
+     * +--------------+----------+----------+
+     * | validationID : [32]byte | 32 bytes |
+     * +--------------+----------+----------+
+     * |        nonce :   uint64 |  8 bytes |
+     * +--------------+----------+----------+
+     * |       weight :   uint64 |  8 bytes |
+     * +--------------+----------+----------+
+     *                           | 54 bytes |
+     *                           +----------+
+     */
+    function packSubnetValidatorWeightUpdateMessage(
+        bytes32 validationID,
+        uint64 nonce,
+        uint64 weight
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            CODEC_ID, SUBNET_VALIDATOR_WEIGHT_UPDATE_MESSAGE_TYPE_ID, validationID, nonce, weight
         );
+    }
+
+    /**
+     * @notice Unpacks a byte array as a SubnetValidatorWeightUpdateMessag.
+     * The message format specification is the same as the one used in above for packing.
+     *
+     * @param input The byte array to unpack.
+     * @return The validationID, weight, and nonce.
+     */
+    function unpackSubnetValidatorWeightUpdateMessage(bytes memory input)
+        internal
+        pure
+        returns (bytes32, uint64, uint64)
+    {
+        if (input.length != 54) {
+            revert InvalidMessageLength();
+        }
+
+        // Unpack the codec ID.
+        uint16 codecID;
+        for (uint256 i; i < 2; ++i) {
+            codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
+        }
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
+
+        // Unpack the type ID.
+        uint32 typeID;
+        for (uint256 i; i < 4; ++i) {
+            typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
+        }
+
+        if (typeID != SUBNET_VALIDATOR_WEIGHT_UPDATE_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
 
         // Unpack the validation ID.
         bytes32 validationID;
@@ -388,25 +594,7 @@ library ValidatorMessages {
         bytes32 validationID,
         uint64 uptime
     ) internal pure returns (bytes memory) {
-        bytes memory res = new bytes(46);
-
-        // Pack the codec ID.
-        for (uint256 i; i < 2; ++i) {
-            res[i] = bytes1(uint8(CODEC_ID >> (8 * (1 - i))));
-        }
-        // Pack the type ID.
-        for (uint256 i; i < 4; ++i) {
-            res[i + 2] = bytes1(uint8(VALIDATION_UPTIME_MESSAGE_TYPE_ID >> (8 * (3 - i))));
-        }
-        // Pack the validation ID.
-        for (uint256 i; i < 32; ++i) {
-            res[i + 6] = bytes1(uint8(uint256(validationID >> (8 * (31 - i)))));
-        }
-        // Pack the uptime.
-        for (uint256 i; i < 8; ++i) {
-            res[i + 38] = bytes1(uint8(uptime >> (8 * (7 - i))));
-        }
-        return res;
+        return abi.encodePacked(CODEC_ID, VALIDATION_UPTIME_MESSAGE_TYPE_ID, validationID, uptime);
     }
 
     /**
@@ -421,23 +609,27 @@ library ValidatorMessages {
         pure
         returns (bytes32, uint64)
     {
-        require(input.length == 46, "ValidatorMessages: Invalid message length");
+        if (input.length != 46) {
+            revert InvalidMessageLength();
+        }
 
         // Unpack the codec ID.
         uint16 codecID;
         for (uint256 i; i < 2; ++i) {
             codecID |= uint16(uint8(input[i])) << uint16((8 * (1 - i)));
         }
-        require(codecID == CODEC_ID, "ValidatorMessages: Invalid codec ID");
+        if (codecID != CODEC_ID) {
+            revert InvalidCodecID();
+        }
 
         // Unpack the type ID.
         uint32 typeID;
         for (uint256 i; i < 4; ++i) {
             typeID |= uint32(uint8(input[i + 2])) << uint32((8 * (3 - i)));
         }
-        require(
-            typeID == VALIDATION_UPTIME_MESSAGE_TYPE_ID, "ValidatorMessages: Invalid message type"
-        );
+        if (typeID != VALIDATION_UPTIME_MESSAGE_TYPE_ID) {
+            revert InvalidMessageType();
+        }
 
         // Unpack the validation ID.
         bytes32 validationID;

--- a/contracts/src/contracts/ACP99/ValidatorMessages.sol
+++ b/contracts/src/contracts/ACP99/ValidatorMessages.sol
@@ -156,7 +156,7 @@ library ValidatorMessages {
      * @param subnetConversionData The struct representing data to pack into the message.
      * @return The packed message.
      */
-    function packSubnetConversionData(SubnetConversionData calldata subnetConversionData)
+    function packSubnetConversionData(SubnetConversionData memory subnetConversionData)
         internal
         pure
         returns (bytes memory)

--- a/contracts/src/interfaces/ACP99/IACP99Manager.sol
+++ b/contracts/src/interfaces/ACP99/IACP99Manager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 import {ValidatorMessages} from "../../contracts/ACP99/ValidatorMessages.sol";
 

--- a/contracts/src/interfaces/ACP99/IACP99Manager.sol
+++ b/contracts/src/interfaces/ACP99/IACP99Manager.sol
@@ -3,6 +3,8 @@
 
 pragma solidity ^0.8.0;
 
+import {ValidatorMessages} from "../../contracts/ACP99/ValidatorMessages.sol";
+
 /// @custom:security-contact security@suzaku.network
 interface IACP99Manager {
     /// @notice Subnet validation status
@@ -50,6 +52,10 @@ interface IACP99Manager {
 
     /// @notice Emitted when the security module address is set
     event SetSecurityModule(address indexed securityModule);
+    /// @notice Emitted when an initial validator is registered
+    event RegisterInitialValidator(
+        bytes32 indexed nodeID, bytes32 indexed validationID, uint64 weight
+    );
     /// @notice Emitted when a validator registration to the Subnet is initiated
     event InitiateValidatorRegistration(
         bytes32 indexed nodeID,
@@ -60,10 +66,7 @@ interface IACP99Manager {
     );
     /// @notice Emitted when a validator registration to the Subnet is completed
     event CompleteValidatorRegistration(
-        bytes32 indexed nodeID,
-        bytes32 indexed validationID,
-        uint64 weight,
-        uint64 validationStartTime
+        bytes32 indexed nodeID, bytes32 indexed validationID, uint64 weight
     );
     /// @notice Emitted when a validator weight update is initiated
     event InitiateValidatorWeightUpdate(
@@ -77,11 +80,19 @@ interface IACP99Manager {
         bytes32 indexed nodeID, bytes32 indexed validationID, uint64 nonce, uint64 weight
     );
 
+    error ACP99Manager__ValidatorSetAlreadyInitialized();
+    error ACP99Manager__InvalidSubnetConversionID(
+        bytes32 subnetConversionID, bytes32 messageSubnetConversionID
+    );
+    error ACP99Manager__InvalidManagerBlockchainID(
+        bytes32 managerBlockchainID, bytes32 conversionBlockchainID
+    );
+    error ACP99Manager__InvalidManagerAddress(address managerAddress, address conversionAddress);
     error ACP99Manager__ZeroAddressSecurityModule();
     error ACP99Manager__OnlySecurityModule(address sender, address securityModule);
     error ACP99Manager__InvalidExpiry(uint64 expiry, uint256 timestamp);
     error ACP99Manager__ZeroNodeID();
-    error ACP99Manager__NodeIDAlreadyValidator(bytes32 nodeID);
+    error ACP99Manager__NodeAlreadyValidator(bytes32 nodeID);
     error ACP99Manager__InvalidSignatureLength(uint256 length);
     error ACP99Manager__InvalidValidationID(bytes32 validationID);
     error ACP99Manager__InvalidWarpMessage();
@@ -112,6 +123,23 @@ interface IACP99Manager {
 
     /// @notice Get the list of message IDs associated with a validator of the Subnet
     function getValidatorValidations(bytes32 nodeID) external view returns (bytes32[] memory);
+
+    /**
+     * @notice Set the address of the security module attached to this manager
+     * @param securityModule_ The address of the security module
+     */
+    function setSecurityModule(address securityModule_) external;
+
+    /**
+     * @notice Verifies and sets the initial validator set for the chain through a P-Chain
+     * SubnetConversionMessage.
+     * @param subnetConversionData The subnet conversion message data used to recompute and verify against the subnetConversionID.
+     * @param messsageIndex The index that contains the SubnetConversionMessage Warp message containing the subnetConversionID to be verified against the provided {subnetConversionData}
+     */
+    function initializeValidatorSet(
+        ValidatorMessages.SubnetConversionData calldata subnetConversionData,
+        uint32 messsageIndex
+    ) external;
 
     /**
      * @notice Initiate a validator registration by issuing a RegisterSubnetValidatorTx Warp message

--- a/contracts/src/interfaces/ACP99/IACP99Manager.sol
+++ b/contracts/src/interfaces/ACP99/IACP99Manager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.0;
 
 /// @custom:security-contact security@suzaku.network
 interface IACP99Manager {

--- a/contracts/src/interfaces/ACP99/IACP99SecurityModule.sol
+++ b/contracts/src/interfaces/ACP99/IACP99SecurityModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.0;
 
 /// @custom:security-contact security@suzaku.network
 interface IACP99SecurityModule {

--- a/contracts/src/interfaces/ACP99/IACP99SecurityModule.sol
+++ b/contracts/src/interfaces/ACP99/IACP99SecurityModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 /// @custom:security-contact security@suzaku.network
 interface IACP99SecurityModule {

--- a/contracts/src/mocks/WarpMessengerTestMock.sol
+++ b/contracts/src/mocks/WarpMessengerTestMock.sol
@@ -23,8 +23,9 @@ contract WarpMessengerTestMock {
         0x1000000000000000000000000000000000000000000000000000000000000000;
     bytes32 private constant MESSAGE_ID =
         0x39fa07214dc7ff1d2f8b6dfe6cd26f6b138ee9d40d013724382a5c539c8641e2;
+    address private constant VALIDATOR_MANAGER_ADDRESS = 0xf06FD5A15c8333CcC2b336D72ECE381c88cB657f;
     bytes32 private constant VALIDATION_ID =
-        0x5b95b95601dce19048a51e797c1910a7da3514f77ed33a75ef69bd8aaf29a3d2;
+        0xe2d4e0a460dd3674dbc90edafc676f80d5a6b402a5c028cdf6c0796c60b2b372;
     uint64 private constant VALIDATION_UPTIME_SECONDS = uint64(2_544_480);
 
     address private immutable tokenHomeAddress;
@@ -45,10 +46,11 @@ contract WarpMessengerTestMock {
 
     // Mocks valid warp messages for testing
     // messageIndex = 1: RegisterRemoteMessage used for AvalancheICTTRouter tests
-    // messageIndex = 2: SubnetValidatorRegistrationMessage used for ACP99Manager tests
-    // messageIndex = 3: ValidatorUptimeMessage used for ACP99Manager tests
-    // messageIndex = 4: ValidatorWeightUpdateMessage used for ACP99Manager tests (weight = 200)
-    // messageIndex = 5: ValidatorWeightUpdateMessage used for ACP99Manager tests (weight = 0)
+    // messageIndex = 2: InitializeValidatorSetMessage used for ACP99Manager tests
+    // messageIndex = 3: SubnetValidatorRegistrationMessage used for ACP99Manager tests
+    // messageIndex = 4: ValidatorUptimeMessage used for ACP99Manager tests
+    // messageIndex = 5: ValidatorWeightUpdateMessage used for ACP99Manager tests (weight = 200)
+    // messageIndex = 6: ValidatorWeightUpdateMessage used for ACP99Manager tests (weight = 0)
     function getVerifiedWarpMessage(uint32 messageIndex)
         external
         view
@@ -57,12 +59,14 @@ contract WarpMessengerTestMock {
         if (messageIndex == 1) {
             return _registerRemoteWarpMessage();
         } else if (messageIndex == 2) {
-            return _subnetValidatorRegistrationWarpMessage();
+            return _initializeValidatorSetWarpMessage();
         } else if (messageIndex == 3) {
-            return _validatorUptimeWarpMessage();
+            return _validatorRegistrationWarpMessage();
         } else if (messageIndex == 4) {
-            return _validatorWeightUpdateWarpMessage();
+            return _validatorUptimeWarpMessage();
         } else if (messageIndex == 5) {
+            return _validatorWeightUpdateWarpMessage();
+        } else if (messageIndex == 6) {
             return _validatorWeightZeroWarpMessage();
         }
     }
@@ -98,11 +102,41 @@ contract WarpMessengerTestMock {
         return (warpMessage, true);
     }
 
-    function _subnetValidatorRegistrationWarpMessage()
-        private
-        pure
-        returns (WarpMessage memory, bool)
-    {
+    function _initializeValidatorSetWarpMessage() private pure returns (WarpMessage memory, bool) {
+        ValidatorMessages.InitialValidator[] memory initialValidators =
+            new ValidatorMessages.InitialValidator[](2);
+        initialValidators[0] = ValidatorMessages.InitialValidator({
+            nodeID: bytes32(uint256(2)),
+            weight: 100,
+            blsPublicKey: new bytes(48)
+        });
+        initialValidators[1] = ValidatorMessages.InitialValidator({
+            nodeID: bytes32(uint256(3)),
+            weight: 100,
+            blsPublicKey: new bytes(48)
+        });
+        ValidatorMessages.SubnetConversionData memory subnetConversionData = ValidatorMessages
+            .SubnetConversionData({
+            convertSubnetTxID: bytes32(uint256(1)),
+            validatorManagerBlockchainID: ANVIL_CHAIN_ID_HEX,
+            validatorManagerAddress: VALIDATOR_MANAGER_ADDRESS,
+            initialValidators: initialValidators
+        });
+
+        WarpMessage memory warpMessage = WarpMessage({
+            sourceChainID: P_CHAIN_ID_HEX,
+            originSenderAddress: address(0),
+            payload: abi.encodePacked(
+                ValidatorMessages.CODEC_ID,
+                ValidatorMessages.SUBNET_CONVERSION_MESSAGE_TYPE_ID,
+                sha256(ValidatorMessages.packSubnetConversionData(subnetConversionData))
+            )
+        });
+
+        return (warpMessage, true);
+    }
+
+    function _validatorRegistrationWarpMessage() private pure returns (WarpMessage memory, bool) {
         WarpMessage memory warpMessage = WarpMessage({
             sourceChainID: P_CHAIN_ID_HEX,
             originSenderAddress: address(0),

--- a/contracts/test/ACP99/ACP99ManagerTest.sol
+++ b/contracts/test/ACP99/ACP99ManagerTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.0;
 
 import {HelperConfig} from "../../script/ACP99/HelperConfig.s.sol";
 import {DeployACP99PoAModule} from "../../script/ACP99/SecurityModules/DeployACP99PoAModule.s.sol";

--- a/contracts/test/ACP99/ACP99ManagerTest.sol
+++ b/contracts/test/ACP99/ACP99ManagerTest.sol
@@ -44,7 +44,7 @@ contract ACP99ManagerTest is Test {
     uint32 constant VALIDATOR_UPTIME_MESSAGE_INDEX = 4;
     uint32 constant COMPLETE_VALIDATOR_WEIGHT_UPDATE_MESSAGE_INDEX = 5;
     uint32 constant COMPLETE_VALIDATION_MESSAGE_INDEX = 6;
-    address constant WARP_MESSENGER_ADDRESS = 0x0200000000000000000000000000000000000005;
+    address constant WARP_MESSENGER_ADDR = 0x0200000000000000000000000000000000000005;
     bytes32 constant VALIDATOR_NODE_ID = bytes32(uint256(1));
     bytes constant VALIDATOR_BLS_PUBLIC_KEY = new bytes(48);
     uint64 constant VALIDATOR_WEIGHT = 100;
@@ -64,7 +64,7 @@ contract ACP99ManagerTest is Test {
 
         WarpMessengerTestMock warpMessengerTestMock =
             new WarpMessengerTestMock(makeAddr("tokenHome"), makeAddr("tokenRemote"));
-        vm.etch(WARP_MESSENGER_ADDRESS, address(warpMessengerTestMock).code);
+        vm.etch(WARP_MESSENGER_ADDR, address(warpMessengerTestMock).code);
 
         DeployACP99PoAModule validatorSetManagerDeployer = new DeployACP99PoAModule();
         (manager, poaModule) = validatorSetManagerDeployer.run();

--- a/contracts/test/ACP99/ACP99PoAModuleTest.sol
+++ b/contracts/test/ACP99/ACP99PoAModuleTest.sol
@@ -19,15 +19,15 @@ contract ACP99PoAModuleTest is Test {
     event ValidatorRemoved(bytes32 indexed nodeID);
     event ValidatorWeightUpdated(bytes32 indexed nodeID, uint64 newWeight);
 
-    uint32 constant COMPLETE_VALIDATOR_REGISTRATION_MESSAGE_INDEX = 2;
-    uint32 constant VALIDATOR_UPTIME_MESSAGE_INDEX = 3;
-    uint32 constant COMPLETE_VALIDATOR_WEIGHT_UPDATE_MESSAGE_INDEX = 4;
+    uint32 constant COMPLETE_VALIDATOR_REGISTRATION_MESSAGE_INDEX = 3;
+    uint32 constant VALIDATOR_UPTIME_MESSAGE_INDEX = 4;
+    uint32 constant COMPLETE_VALIDATOR_WEIGHT_UPDATE_MESSAGE_INDEX = 5;
     address constant WARP_MESSENGER_ADDRESS = 0x0200000000000000000000000000000000000005;
     bytes32 constant VALIDATOR_NODE_ID = bytes32(uint256(1));
     bytes constant VALIDATOR_BLS_PUBLIC_KEY = new bytes(48);
     uint64 constant VALIDATOR_WEIGHT = 100;
     bytes32 constant VALIDATION_ID =
-        0x5b95b95601dce19048a51e797c1910a7da3514f77ed33a75ef69bd8aaf29a3d2;
+        0xe2d4e0a460dd3674dbc90edafc676f80d5a6b402a5c028cdf6c0796c60b2b372;
 
     ACP99PoAModule poaModule;
     uint256 deployerKey;
@@ -55,7 +55,7 @@ contract ACP99PoAModuleTest is Test {
         uint64 registrationExpiry = uint64(block.timestamp + 1 days);
 
         vm.prank(deployerAddress);
-        // validationID = 0x5b95b95601dce19048a51e797c1910a7da3514f77ed33a75ef69bd8aaf29a3d2
+        // validationID = 0xe2d4e0a460dd3674dbc90edafc676f80d5a6b402a5c028cdf6c0796c60b2b372
         poaModule.addValidator(
             VALIDATOR_NODE_ID, VALIDATOR_WEIGHT, registrationExpiry, VALIDATOR_BLS_PUBLIC_KEY
         );
@@ -66,7 +66,7 @@ contract ACP99PoAModuleTest is Test {
         uint64 registrationExpiry = uint64(block.timestamp + 1 days);
 
         vm.startPrank(deployerAddress);
-        // validationID = 0x5b95b95601dce19048a51e797c1910a7da3514f77ed33a75ef69bd8aaf29a3d2
+        // validationID = 0xe2d4e0a460dd3674dbc90edafc676f80d5a6b402a5c028cdf6c0796c60b2b372
         poaModule.addValidator(
             VALIDATOR_NODE_ID, VALIDATOR_WEIGHT, registrationExpiry, VALIDATOR_BLS_PUBLIC_KEY
         );

--- a/contracts/test/ACP99/ACP99PoAModuleTest.sol
+++ b/contracts/test/ACP99/ACP99PoAModuleTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2024 ADDPHO
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.0;
 
 import {HelperConfig} from "../../script/ACP99/HelperConfig.s.sol";
 import {DeployACP99PoAModule} from "../../script/ACP99/SecurityModules/DeployACP99PoAModule.s.sol";

--- a/contracts/test/ACP99/ACP99PoAModuleTest.sol
+++ b/contracts/test/ACP99/ACP99PoAModuleTest.sol
@@ -22,7 +22,7 @@ contract ACP99PoAModuleTest is Test {
     uint32 constant COMPLETE_VALIDATOR_REGISTRATION_MESSAGE_INDEX = 3;
     uint32 constant VALIDATOR_UPTIME_MESSAGE_INDEX = 4;
     uint32 constant COMPLETE_VALIDATOR_WEIGHT_UPDATE_MESSAGE_INDEX = 5;
-    address constant WARP_MESSENGER_ADDRESS = 0x0200000000000000000000000000000000000005;
+    address constant WARP_MESSENGER_ADDR = 0x0200000000000000000000000000000000000005;
     bytes32 constant VALIDATOR_NODE_ID = bytes32(uint256(1));
     bytes constant VALIDATOR_BLS_PUBLIC_KEY = new bytes(48);
     uint64 constant VALIDATOR_WEIGHT = 100;
@@ -42,7 +42,7 @@ contract ACP99PoAModuleTest is Test {
 
         WarpMessengerTestMock warpMessengerTestMock =
             new WarpMessengerTestMock(makeAddr("tokenHome"), makeAddr("tokenRemote"));
-        vm.etch(WARP_MESSENGER_ADDRESS, address(warpMessengerTestMock).code);
+        vm.etch(WARP_MESSENGER_ADDR, address(warpMessengerTestMock).code);
 
         DeployACP99PoAModule poaModuleDeployer = new DeployACP99PoAModule();
         (manager, poaModule) = poaModuleDeployer.run();

--- a/defender.config.json
+++ b/defender.config.json
@@ -1,0 +1,9 @@
+{
+  "contract_inspector": {
+    "enabled": true,
+    "scan_directories": ["contracts/src/"]
+  },
+  "dependency_checker": {
+    "enabled": true
+  }
+}

--- a/defender.config.json
+++ b/defender.config.json
@@ -1,7 +1,7 @@
 {
   "contract_inspector": {
     "enabled": true,
-    "scan_directories": ["contracts/src/"]
+    "scan_directories": ["contracts/src/contracts", "contracts/src/interfaces"]
   },
   "dependency_checker": {
     "enabled": true


### PR DESCRIPTION
### Changes

- ACP99
  - Reflect the latest updates of ACP-77 to support the validator set initialization upon `ConvertSubnetTx`
    - Update `ValidatorMessages`
    - Add `initializeValidatorSet` function

### Additional comments

I used the latest version of `ValidatorMessages` available on the [validator-manager](https://github.com/ava-labs/teleporter/tree/validator-manager) branch of the `teleporter` repo. Used the same branch to understand the logic of `initializeValidatorSet`.

See https://github.com/avalanche-foundation/ACPs/pull/146 for reference.
