### PR TITLE
feat(ValidatorManager): bump to v1.0.0 + test validator migration

### DIFF
--- a/src/interfaces/ValidatorManager/IBalancerValidatorManager.sol
+++ b/src/interfaces/ValidatorManager/IBalancerValidatorManager.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.25;
 
 import {
     IValidatorManager,
+    ValidatorChurnPeriod,
     ValidatorManagerSettings,
     ValidatorRegistrationInput
 } from "@avalabs/icm-contracts/validator-manager/interfaces/IValidatorManager.sol";
@@ -34,6 +35,9 @@ interface IBalancerValidatorManager is IValidatorManager {
      */
     event SetupSecurityModule(address indexed securityModule, uint64 maxWeight);
 
+    error BalancerValidatorManager__MigratedValidatorsTotalWeightMismatch(
+        uint64 migratedValidatorsTotalWeight, uint64 currentL1TotalWeight
+    );
     error BalancerValidatorManager__SecurityModuleAlreadyRegistered(address securityModule);
     error BalancerValidatorManager__SecurityModuleNotRegistered(address securityModule);
     error BalancerValidatorManager__SecurityModuleMaxWeightExceeded(
@@ -55,6 +59,21 @@ interface IBalancerValidatorManager is IValidatorManager {
      * @return churnPeriodSeconds The churn period in seconds
      */
     function getChurnPeriodSeconds() external view returns (uint64 churnPeriodSeconds);
+
+    /**
+     * @notice Returns the maximum churn rate per churn period (in percentage)
+     * @return maximumChurnPercentage The maximum churn percentage
+     */
+    function getMaximumChurnPercentage() external view returns (uint64 maximumChurnPercentage);
+
+    /**
+     * @notice Returns the current churn period
+     * @return churnPeriod The current churn period
+     */
+    function getCurrentChurnPeriod()
+        external
+        view
+        returns (ValidatorChurnPeriod memory churnPeriod);
 
     /**
      * @notice Returns the list of registered security modules

--- a/test/ValidatorManager/PoAToBalancerValidatorManagerTest.t.sol
+++ b/test/ValidatorManager/PoAToBalancerValidatorManagerTest.t.sol
@@ -218,6 +218,34 @@ contract PoAToBalancerValidatorManagerTest is Test {
         assertEq(validator.weight, 180);
     }
 
+    function testUpgradeToBalancerValidatorManagerRevertsIfMissingMigratedValidators() public {
+        bytes[] memory migratedValidators = new bytes[](1);
+        migratedValidators[0] = VALIDATOR_NODE_ID_02;
+
+        vm.startBroadcast(proxyAdminOwnerKey);
+        Upgrades.upgradeProxy(
+            validatorManagerProxyAddress,
+            "BalancerValidatorManager.sol:BalancerValidatorManager",
+            ""
+        );
+        BalancerValidatorManager balancerValidatorManager =
+            BalancerValidatorManager(validatorManagerProxyAddress);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IBalancerValidatorManager
+                    .BalancerValidatorManager__MigratedValidatorsTotalWeightMismatch
+                    .selector,
+                180,
+                200
+            )
+        );
+        balancerValidatorManager.initialize(
+            _generateTestBalancerValidatorManagerSettings(migratedValidators)
+        );
+        vm.stopBroadcast();
+    }
+
     function testUpgradeToBalancerValidatorManagerWithPoAValidator() public {
         // Add another validator before upgrading
         vm.startPrank(validatorManagerOwnerAddress);


### PR DESCRIPTION
### Linked issues

- Fixes #52 

### Changes

- ValidatorManager
  - Bump `icm-contracts` version to `validator-manager-v1.0.0`
  - Add getters to `BalancerValidatorManager` and associated tests
  - Add a check on the migrated validators' total weight upon migration in `BalancerValidatorManager`
