### PR TITLE
fix: vm check

### DIFF
--- a/src/contracts/ValidatorManager/BalancerValidatorManager.sol
+++ b/src/contracts/ValidatorManager/BalancerValidatorManager.sol
@@ -97,9 +97,6 @@ contract BalancerValidatorManager is IBalancerValidatorManager, OwnableUpgradeab
             revert BalancerValidatorManager__ZeroValidatorManagerAddress();
         }
         VALIDATOR_MANAGER = ValidatorManager(validatorManagerAddress);
-        if (VALIDATOR_MANAGER.owner() != address(this)) {
-            revert BalancerValidatorManager__ValidatorManagerNotOwnedByBalancer();
-        }
         if (!VALIDATOR_MANAGER.isValidatorSetInitialized()) {
             revert BalancerValidatorManager__VMValidatorSetNotInitialized();
         }

--- a/src/interfaces/ValidatorManager/IBalancerValidatorManager.sol
+++ b/src/interfaces/ValidatorManager/IBalancerValidatorManager.sol
@@ -79,7 +79,6 @@ interface IBalancerValidatorManager is IValidatorManager {
     error BalancerValidatorManager__InvalidNonce(uint64 nonce);
     error BalancerValidatorManager__ValidatorAlreadyMigrated(bytes32 validationID);
     error BalancerValidatorManager__ZeroValidatorManagerAddress();
-    error BalancerValidatorManager__ValidatorManagerNotOwnedByBalancer();
     error BalancerValidatorManager__InitialSecurityModuleRequiredForMigration();
     error BalancerValidatorManager__MigratedValidatorsRequired();
     error BalancerValidatorManager__InvalidWarpMessage();


### PR DESCRIPTION
### Linked issues

<!-- List of issues this PR fixes. E.g.

- Fixes #12
- Fixes #14

-->

### Dependencies

<!-- List of PR that need to be merged before this PR. E.g.

- https://github.com/AshAvalanche/ash-infra/pull/26
- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/32

If empty, please remove the section title -->

### Changes

<!-- List of changes brought by the PR. Proposed format: "- Scope\n  - Description". E.g.

- SDK
  - Add 4 networks with [Ankr](https://www.ankr.com/) and [Blast](https://blastapi.io/) endpoints to `conf/default.yml` (e.g. `fuji-ankr`). Both services provide decentralized public RPC endpoints. This allows going around Ava Labs' public RPC rate limiting which is very low.
- CI
  - Add a GitHub Actions workflow to run tests on PRs

-->

### Breaking changes

<!-- List of breaking changes brought by the PR. Proposed format: "- _(scope)_ Description". E.g.

- _(node role)_ `avalanche_tracked_subnets` has been renamed to `avalanchego_track_subnets`

-->

### Additional comments

<!-- You can for example ask for feedback here or link to new issues deriving from the PR.
If empty, please remove the section title -->
